### PR TITLE
Switch masks to YAML and add controller status parser

### DIFF
--- a/scripts/mock_controller.py
+++ b/scripts/mock_controller.py
@@ -24,6 +24,40 @@ _state = {
 _state_lock = Lock()
 
 
+def _build_status_string() -> str:
+    """Construct hex status string similar to real controller."""
+    with _state_lock:
+        program = _state["program"]
+        phase = _state["phase"]
+        time_left = int(_state["time_left"])
+        base_time = PROGRAM_DEFINITIONS[program][phase]
+
+    now = time.localtime()
+    fields = [
+        now.tm_sec,
+        now.tm_min,
+        now.tm_hour,
+        now.tm_wday + 1,
+        now.tm_mday,
+        now.tm_mon,
+        now.tm_year - 2000,
+        program,
+        phase,
+        0,
+        phase,
+        0,
+        0,
+        0,
+        base_time,
+        time_left,
+        base_time - time_left,
+        0,
+        0,
+    ]
+    hex_str = ''.join(f"{b:02X}" for b in fields)
+    return f"wsO_CMD:electric_coal:x{hex_str}"
+
+
 class ProgramRequest(BaseModel):
     program: int
 
@@ -48,17 +82,8 @@ async def set_program(req: ProgramRequest):
 
 @app.get("/api/phase_status")
 async def phase_status():
-    """
-    Возвращает:
-      phase: индекс фазы (0,1,2)
-      time_left: сколько секунд осталось до конца этой фазы
-    """
-    with _state_lock:
-        return {
-            "program": _state["program"],
-            "phase": _state["phase"],
-            "time_left": _state["time_left"],
-        }
+    """Возвратить строку статуса контроллера в шестнадцатеричном виде."""
+    return _build_status_string()
 
 
 def _phase_timer_loop():

--- a/src/controller_client.py
+++ b/src/controller_client.py
@@ -1,6 +1,7 @@
 import requests
 import logging
 from config import Config
+from status_parser import parse_status_message
 
 class ControllerClient:
     """
@@ -43,10 +44,15 @@ class ControllerClient:
         
     def get_phase_status(self) -> dict:
         """
-        Запрос к /api/phase_status, возвращает dict:
-          { "program": int, "phase": int, "time_left": float }
+        Запрос к /api/phase_status. Эндпоинт возвращает строку с шестнадцатеричным
+        статусом контроллера. Строка разбирается функцией `parse_status_message`.
+        Возвращается словарь, содержащий как минимум `program`, `phase` и
+        `time_left`.
         """
         url = f"{self._base}/phase_status"
         r = requests.get(url, timeout=self._timeout)
         r.raise_for_status()
-        return r.json()
+        status_str = r.text.strip()
+        data = parse_status_message(status_str)
+        self._log.debug(f"Parsed status: {data}")
+        return data

--- a/src/status_parser.py
+++ b/src/status_parser.py
@@ -1,0 +1,91 @@
+import datetime
+
+
+def _byte(hex_data: str, index: int) -> int:
+    return int(hex_data[2 * index: 2 * index + 2], 16)
+
+
+def parse_status_message(message: str) -> dict:
+    """Parse controller status message string.
+
+    The message is expected in format ``wsO_CMD:electric_coal:x<HEX>`` where
+    ``<HEX>`` is a sequence of hexadecimal byte values.
+    Returns a dictionary with at least keys ``program``, ``phase`` and
+    ``time_left``. Extra fields are also provided for completeness.
+    """
+    if 'x' not in message:
+        raise ValueError('Invalid status message')
+    hex_data = message.split('x', 1)[1].strip()
+    if len(hex_data) % 2 != 0:
+        raise ValueError('Odd length of hex payload')
+
+    def b(idx: int) -> int:
+        return int(hex_data[2 * idx: 2 * idx + 2], 16)
+
+    seconds = b(0)
+    minutes = b(1)
+    hours = b(2)
+    week_day = b(3)
+    day = b(4)
+    month = b(5)
+    year = 2000 + b(6)
+
+    plan_number = b(7)
+
+    phase_low = b(8)
+    phase_high = b(9)
+    tact_low = b(10)
+    tact_high = b(11)
+
+    tact_flags = b(12)
+    min_time = b(13)
+    base_time = b(14)
+    remaining_time = b(15)
+    current_cycle_second = b(16)
+
+    tvp_status = b(17)
+    additional_status = b(18)
+
+    result = {
+        'datetime': datetime.datetime(year, month, day, hours, minutes, seconds),
+        'week_day': week_day,
+        'program': plan_number,
+        'phase': phase_low,
+        'tact': tact_low,
+        'tact_flags': tact_flags,
+        'min_time': min_time,
+        'base_time': base_time,
+        'time_left': remaining_time,
+        'cycle_second': current_cycle_second,
+        'tvp_status': tvp_status,
+        'additional_status': additional_status,
+    }
+
+    # convenience boolean flags
+    result.update({
+        'main_tact': bool(tact_flags & 0x01),
+        'prom_tact': bool(tact_flags & 0x02),
+        'tvp1_tact': bool(tact_flags & 0x04),
+        'tvp2_tact': bool(tact_flags & 0x08),
+        'is_last_tact': bool(tact_flags & 0x10),
+        'door_open': bool(tact_flags & 0x40),
+        'power_signal': bool(tact_flags & 0x80),
+        'tvp1_call': bool(tvp_status & 0x01),
+        'tvp2_call': bool(tvp_status & 0x02),
+        'tvp1_phase': bool(tvp_status & 0x04),
+        'tvp2_phase': bool(tvp_status & 0x08),
+        'manual_mode': bool(tvp_status & 0x10),
+        'app_mode': bool(tvp_status & 0x20),
+        'tvp1_inactive': bool(tvp_status & 0x40),
+        'tvp2_inactive': bool(tvp_status & 0x80),
+        'fast_plan_change': bool(additional_status & 0x01),
+        'fast_plan_change_mode': bool(additional_status & 0x02),
+        'center_plan_change': bool(additional_status & 0x04),
+        'center_plan_active': bool(additional_status & 0x08),
+        'vf_mode_activated': bool(additional_status & 0x10),
+        'vf_mode': bool(additional_status & 0x20),
+        'engineer_mode': bool(additional_status & 0x40),
+        'emergency_mode': bool(additional_status & 0x80),
+    })
+
+    return result

--- a/src/video_capture.py
+++ b/src/video_capture.py
@@ -1,5 +1,5 @@
 import cv2
-import json
+import yaml
 import os
 import logging
 import numpy as np
@@ -8,7 +8,8 @@ from config import Config
 class VideoCapture:
     """
     Захват и маскирование кадров из RTSP-потоков или файлов.
-    Маски хранятся в директории mask_dir в формате JSON с ключом "polygons": [ [x,y], ... ].
+    Маски хранятся в YAML-файлах `zone_<cam_id>.yaml` в директории mask_dir.
+    Каждый файл должен содержать список зон со списком точек в поле `points`.
     """
     def __init__(self, config: Config):
         self._cams = config.get('cameras') or {}
@@ -29,12 +30,25 @@ class VideoCapture:
 
     def _load_masks(self):
         for cam_id in self._cams:
-            path = os.path.join(self._mask_dir, f"cam{cam_id}_mask.json")
+            path = os.path.join(self._mask_dir, f"zone_{cam_id}.yaml")
             if os.path.isfile(path):
-                with open(path, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                    self._masks[cam_id] = data.get('polygons', [])
+                try:
+                    with open(path, 'r', encoding='utf-8') as f:
+                        data = yaml.safe_load(f)
+                    polygons = []
+                    if isinstance(data, dict):
+                        if 'zones' in data and isinstance(data['zones'], list):
+                            for zone in data['zones']:
+                                pts = zone.get('points', [])
+                                if pts:
+                                    polygons.append(pts)
+                        elif 'points' in data:
+                            polygons.append(data.get('points', []))
+                    self._masks[cam_id] = polygons
                     self._log.debug(f"Loaded mask for cam {cam_id}")
+                except Exception as e:
+                    self._masks[cam_id] = []
+                    self._log.error(f"Failed to load mask for cam {cam_id}: {e}")
             else:
                 self._masks[cam_id] = []
                 self._log.warning(f"Mask file not found for cam {cam_id}, no masking applied.")


### PR DESCRIPTION
## Summary
- load camera mask polygons from `zone_<id>.yaml`
- parse controller hex status strings with new `status_parser` module
- update controller client to consume hex strings
- emit hex status strings from mock controller

## Testing
- `python -m py_compile src/video_capture.py src/controller_client.py src/status_parser.py scripts/mock_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_6886aea9e908832fb3f4968043c42744