### PR TITLE
Add Jetson Docker support and TensorRT export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 *.mp4
 *.pt
+*.engine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ultralytics/ultralytics:latest-jetson
+
+WORKDIR /app
+COPY . /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssh-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /var/run/sshd \
+    && echo 'root:root' | chpasswd
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 5000 8000 8554 22
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install -r requirements.txt
         "3": "rtsp://localhost:8554/cam1"
     },
     "detector": {
-        "model_path": "models/yolov5s.onnx",
+        "model_path": "models/yolo11s.engine",
         "input_size": 640,
         "confidence_threshold": 0.25,
         "nms_threshold": 0.45
@@ -91,4 +91,30 @@ python scripts/mock_controller.py
 ## Демонстрационное приложение
 
 Файл `demo.py` реализует GUI‐демонстрацию на PyQt6 с визуализацией зон и статистики по трём камерам. Для редактирования масок зон можно использовать `drow_zones.py`.
+
+## Экспорт модели в TensorRT
+
+Для ускорения работы на устройствах NVIDIA Jetson модель можно экспортировать в формат TensorRT:
+
+```bash
+python scripts/export_tensorrt.py --model yolo11s.pt --output models/yolo11s.engine
+```
+
+После конвертации путь к модели в `config/default.json` должен указывать на файл `.engine`.
+
+## Docker
+
+Собрать образ всего проекта на базе официального Jetson‑контейнера ultralytics:
+
+```bash
+docker build -t neyro_det .
+```
+
+Запуск сервиса (порт контроллера 5000, RTSP 8554, эмулятор камер 8000, SSH 22):
+
+```bash
+docker run -p 5000:5000 -p 8554:8554 -p 8000:8000 -p 22:22 neyro_det
+```
+
+После запуска контейнера приложение стартует автоматически, а к оболочке можно подключиться по SSH (логин `root`, пароль `root`).
 

--- a/config/default.json
+++ b/config/default.json
@@ -10,7 +10,7 @@
         "3": "rtsp://localhost:8554/cam1"
     },
     "detector": {
-        "model_path": "yolo11s.pt",
+        "model_path": "models/yolo11s.engine",
         "input_size": 640,
         "confidence_threshold": 0.25,
         "nms_threshold": 0.45

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+service ssh start
+exec python -m src

--- a/scripts/export_tensorrt.py
+++ b/scripts/export_tensorrt.py
@@ -1,0 +1,31 @@
+import argparse
+import shutil
+from ultralytics import YOLO
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export a YOLO model to TensorRT engine format")
+    parser.add_argument(
+        "--model", default="yolo11s.pt",
+        help="Path to the source .pt model")
+    parser.add_argument(
+        "--imgsz", type=int, default=640,
+        help="Image size used during export")
+    parser.add_argument(
+        "--device", default=0,
+        help="Device ID to use for export")
+    parser.add_argument(
+        "--output", default="models/yolo11s.engine",
+        help="Destination path for the TensorRT engine")
+    args = parser.parse_args()
+
+    yolo = YOLO(args.model)
+    engine_path = yolo.export(format="engine", imgsz=args.imgsz,
+                              device=args.device, half=True)
+    shutil.move(engine_path, args.output)
+    print(f"TensorRT engine saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/detector.py
+++ b/src/detector.py
@@ -18,10 +18,14 @@ class Detector:
 
         self._log = logging.getLogger(self.__class__.__name__)
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        if model_path.endswith(".engine"):
+            # TensorRT engine runs on GPU 0 without torch device strings
+            self._device = 0
+        else:
+            self._device = "cuda" if torch.cuda.is_available() else "cpu"
         self._model = YOLO(model_path)
-        self._device = device
-        self._log.info(f"YOLO model loaded from {model_path} on {device}")
+        self._log.info(
+            f"YOLO model loaded from {model_path} on {self._device}")
 
     def predict(self, frame: np.ndarray) -> List[List[int]]:
         """Вернуть список прямоугольников [x, y, w, h] для класса 'car'."""


### PR DESCRIPTION
## Summary
- Add Dockerfile based on Ultralytics Jetson image with SSH, exposed ports and entrypoint
- Provide export_tensorrt.py script to convert YOLO models to TensorRT engines
- Load `.engine` models in detector and update configuration and docs

## Testing
- `python -m py_compile src/detector.py scripts/export_tensorrt.py`
- `python scripts/export_tensorrt.py --help` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6891bcd6c8c0832f80faf3092d910f4a