### PR TITLE
Fix stride handling and relative imports

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-from config import Config
+from .config import Config

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,13 +1,13 @@
 # src/__main__.py
 import time
 import logging
-from config import Config
-from logger import setup_logging
-from controller_client import ControllerClient
-from video_capture import VideoCapture
-from detector import Detector
-from analyzer import CountsAggregator
-from decision import DecisionEngine
+from .config import Config
+from .logger import setup_logging
+from .controller_client import ControllerClient
+from .video_capture import VideoCapture
+from .detector import Detector
+from .analyzer import CountsAggregator
+from .decision import DecisionEngine
 
 def do_detection_cycle(vc, detector, decision, ctrl, logger, phase):
     """

--- a/src/controller_client.py
+++ b/src/controller_client.py
@@ -1,7 +1,7 @@
 import requests
 import logging
-from config import Config
-from status_parser import parse_status_message
+from .config import Config
+from .status_parser import parse_status_message
 
 class ControllerClient:
     """

--- a/src/decision.py
+++ b/src/decision.py
@@ -1,5 +1,5 @@
 import logging
-from config import Config
+from .config import Config
 
 class DecisionEngine:
     """State machine for selecting traffic light programs (4-11)."""

--- a/src/detector.py
+++ b/src/detector.py
@@ -7,7 +7,7 @@ import cv2
 import numpy as np
 import torch
 
-from config import Config
+from .config import Config
 
 
 class Detector:
@@ -37,7 +37,12 @@ class Detector:
         self._scale = scale_boxes
         self._device = select_device("0" if torch.cuda.is_available() else "cpu")
         self._model = DetectMultiBackend(model_path, device=self._device)
-        self._stride = int(self._model.stride.max())
+        stride = self._model.stride
+        if hasattr(stride, "max"):
+            stride = stride.max()
+        elif isinstance(stride, (list, tuple)):
+            stride = max(stride)
+        self._stride = int(stride)
         self._log.info(f"YOLOv5 model loaded from {model_path} on {self._device}")
 
     def _preprocess(self, frame: np.ndarray) -> torch.Tensor:

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from logging.handlers import RotatingFileHandler
-from config import Config
+from .config import Config
 
 
 def setup_logging(config: Config) -> None:

--- a/src/sample_inference.py
+++ b/src/sample_inference.py
@@ -1,6 +1,6 @@
 import cv2
-from config import Config
-from detector import Detector
+from .config import Config
+from .detector import Detector
 
 def main():
     config = Config()

--- a/src/video_capture.py
+++ b/src/video_capture.py
@@ -3,7 +3,7 @@ import yaml
 import os
 import logging
 import numpy as np
-from config import Config
+from .config import Config
 
 class VideoCapture:
     """


### PR DESCRIPTION
## Summary
- Avoid calling `.max()` on integer model stride
- Use package-relative imports so `python -m src` works

## Testing
- `/usr/bin/python3 -m py_compile $(/bin/ls src/*.py)`
- `/usr/bin/python3 -m src` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6899c5d2a1a4832fb52b319217a548be