### PR TITLE
Switch controller communication to TCP

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
     "controller": {
-        "serial_port": "/dev/ttyUSB0",
-        "baudrate": 9600,
+        "host": "192.168.1.33",
+        "listen_port": 1030,
         "timeout": 1,
         "poll_interval_sec": 1,
         "traffic_phase_lead_sec": 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ numpy==1.19.4
 
 # opencv-python # Ignorin on jetson nano | use: sudo apt install python3-opencv
 requests>=2.23.0
-pyserial
 fastapi==0.63.0
 uvicorn[standard]==0.11.8
 # PyQt6  # Ignorin on jetson nano

--- a/src/controller_client.py
+++ b/src/controller_client.py
@@ -1,14 +1,13 @@
 import logging
 from typing import Tuple
-
-import serial
+import socket
 
 from .config import Config
 from .status_parser import parse_status_message
 
 
 class ControllerClient:
-    """Коммуникация с контроллером по последовательному интерфейсу.
+    """Коммуникация с контроллером по TCP/IP.
 
     Обмен ведётся согласно протоколу КДУ-3:
 
@@ -28,12 +27,28 @@ class ControllerClient:
 
     def __init__(self, config: Config) -> None:
         ctrl_cfg = config.get("controller") or {}
-        port = ctrl_cfg.get("serial_port", "/dev/ttyUSB0")
-        baud = ctrl_cfg.get("baudrate", 9600)
+        host = ctrl_cfg.get("host", "192.168.1.33")
+        port = ctrl_cfg.get("listen_port", 1030)
         timeout = ctrl_cfg.get("timeout", 1)
 
         self._log = logging.getLogger(self.__class__.__name__)
-        self._ser = serial.Serial(port, baudrate=baud, timeout=timeout)
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("", port))
+        server.listen(1)
+        server.settimeout(timeout)
+        self._log.info("Waiting for controller connection on port %s", port)
+        try:
+            self._sock, addr = server.accept()
+        except socket.timeout:
+            server.close()
+            raise TimeoutError("Controller connection timeout")
+        if addr[0] != host:
+            self._log.warning("Unexpected controller IP %s", addr[0])
+        self._log.info("Controller connected: %s", addr)
+        self._sock.settimeout(timeout)
+        self._server = server
 
     # ------------------------------------------------------------------
     # low level helpers
@@ -51,8 +66,17 @@ class ControllerClient:
         """Send command and return tuple (result, data)."""
         msg = self._build(com, arg)
         self._log.debug("-> %r", msg)
-        self._ser.write(msg)
-        line = self._ser.readline().decode("ascii").strip()
+        self._sock.sendall(msg)
+        data = b""
+        try:
+            while not data.endswith(b"\n"):
+                chunk = self._sock.recv(1024)
+                if not chunk:
+                    break
+                data += chunk
+        except socket.timeout:
+            raise TimeoutError("No response from controller")
+        line = data.decode("ascii").strip()
         self._log.debug("<- %s", line)
         if not line:
             raise TimeoutError("No response from controller")
@@ -96,8 +120,10 @@ class ControllerClient:
 
     # ------------------------------------------------------------------
     def close(self) -> None:
-        if self._ser.is_open:
-            self._ser.close()
+        if getattr(self, "_sock", None):
+            self._sock.close()
+        if getattr(self, "_server", None):
+            self._server.close()
 
 
 __all__ = ["ControllerClient"]


### PR DESCRIPTION
## Summary
- connect to controller over TCP socket instead of serial port
- configure controller IP/port in default config
- drop pyserial dependency
- listen for controller connection and validate remote IP

## Testing
- `python -m py_compile src/controller_client.py src/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad9257c180832f92e43ab7ded2417a