### PR TITLE
Handle controller greeting

### DIFF
--- a/src/controller_client.py
+++ b/src/controller_client.py
@@ -50,6 +50,29 @@ class ControllerClient:
         self._sock.settimeout(timeout)
         self._server = server
 
+        # Контроллер может посылать приветственное сообщение сразу после
+        # установления соединения. Оно не соответствует протоколу КДУ-3 и
+        # сбивает дальнейший обмен (появляется ошибка "Unexpected response").
+        # Чтобы избежать этого, читаем и игнорируем все данные, пришедшие
+        # до первого перевода строки.
+        try:
+            self._sock.settimeout(0.5)
+            greeting = b""
+            while True:
+                try:
+                    chunk = self._sock.recv(1024)
+                    if not chunk:
+                        break
+                    greeting += chunk
+                    if greeting.endswith(b"\n"):
+                        break
+                except socket.timeout:
+                    break
+            if greeting:
+                self._log.debug("Controller greeting: %r", greeting)
+        finally:
+            self._sock.settimeout(timeout)
+
 
     # ------------------------------------------------------------------
     # low level helpers


### PR DESCRIPTION
## Summary
- ignore non-protocol greeting messages from controller to avoid `Unexpected response`

## Testing
- `python3 -m src` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68ad99b0d288832f895515a82439c592