### PR TITLE
Emulate detector without controller

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,71 +1,78 @@
 # src/__main__.py
-import time
+
+"""Entry point that emulates work without a controller.
+
+The application connects to cameras defined in the config file and every
+10 seconds runs object detection on one of two directions (main and side).
+Results are logged to console and file.  When the detector or video capture
+cannot be initialised, random numbers are reported instead.
+"""
+
 import logging
+import random
+import time
+
 from .config import Config
 from .logger import setup_logging
-from .controller_client import ControllerClient
-from .video_capture import VideoCapture
-from .detector import Detector
 from .analyzer import CountsAggregator
-from .decision import DecisionEngine
 
-def do_detection_cycle(vc, detector, decision, ctrl, logger, phase):
-    """
-    Захват N кадров, подсчёт машин, решение и смена программы.
-    phase: текущая фаза светофора (0 или 1).
-    """
-    shots = cfg.get('analysis', 'shots_per_phase')
-    agg_main, agg_side = CountsAggregator(), CountsAggregator()
-    for _ in range(shots):
-        f1 = vc.read('1'); f2 = vc.read('2')
-        agg_main.add(len(detector.predict(f1)) + len(detector.predict(f2)))
-        f3 = vc.read('3')
-        agg_side.add(len(detector.predict(f3)))
 
-    avg_main = agg_main.average()
-    avg_side = agg_side.average()
-    prog = ctrl.get_current_program()
-    new_prog = decision.update_and_decide(phase, prog, avg_main, avg_side)
-
-    if new_prog != prog:
-        ctrl.set_program(new_prog)
-
-    logger.info(
-        f"Cycle complete: prog={prog}, phase={phase}, "
-        f"avg_main={avg_main:.1f}, avg_side={avg_side:.1f}, new={new_prog}"
-    )
-
-if __name__ == '__main__':
-    # Загрузка конфига и логгера
+def main() -> None:
     cfg = Config()
     setup_logging(cfg)
     log = logging.getLogger()
 
-    # Инициализация модулей
-    ctrl = ControllerClient(cfg)
-    vc = VideoCapture(cfg)
-    det = Detector(cfg)
-    dec = DecisionEngine(cfg)
+    log.info("Controller connection established (stub)")
 
-    lead = cfg.get('controller', 'traffic_phase_lead_sec', default=2)
-    log.info("Starting neyro_det service...")
+    # Optional detector initialisation
+    detector = None
+    try:
+        from .detector import Detector  # heavy import
 
+        detector = Detector(cfg)
+        log.info("Detector model loaded")
+    except Exception as exc:  # pragma: no cover - depends on environment
+        log.warning("Detector unavailable, using random counts: %s", exc)
+
+    # Optional video capture initialisation
+    vc = None
+    try:
+        from .video_capture import VideoCapture
+
+        vc = VideoCapture(cfg)
+    except Exception as exc:  # pragma: no cover - depends on environment
+        log.warning("Video capture unavailable, using random frames: %s", exc)
+
+    # Map directions to camera ids
+    directions = [
+        ("main", ["1", "2"]),
+        ("side", ["3"]),
+    ]
+
+    shots = cfg.get("analysis", "shots_per_phase", default=1)
+
+    idx = 0
     try:
         while True:
-            status = ctrl.get_phase_status()
-            prog = status['program']
-            phase = status['phase']
-            time_left = status['time_left']
-            log.info(f"Checking object phase...\nphase={phase}, time_left={time_left:.1f}s")
-            log.debug(f"Prog={prog}, phase={phase}, time_left={time_left:.1f}s")
-
-            # Когда до конца зелёного остаётся <= lead и после этой фазы включается красный
-            if phase in (0, 1) and time_left <= lead:
-                do_detection_cycle(vc, det, dec, ctrl, log, phase)
-                # чтобы не повторяться в одной фазе
-                time.sleep(lead + 0.1)
-            else:
-                time.sleep(0.2)
-
+            name, cam_ids = directions[idx % len(directions)]
+            agg = CountsAggregator()
+            for _ in range(shots):
+                count = 0
+                for cam_id in cam_ids:
+                    frame = vc.read(cam_id) if vc is not None else None
+                    if detector is not None and frame is not None:
+                        count += len(detector.predict(frame))
+                    else:
+                        count += random.randint(0, 5)
+                agg.add(count)
+            avg = int(round(agg.average()))
+            log.info("Detected %d cars on %s direction", avg, name)
+            idx += 1
+            time.sleep(10)
     except KeyboardInterrupt:
         log.info("Shutting down neyro_det service")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- load camera streams from config and stub controller connection
- alternate between main and side directions every 10s and log averaged car counts, using random values if detection or capture is unavailable

## Testing
- `python -m src & sleep 22; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68aed1291d70832f84dbe3497f5bfb3e