### PR TITLE
Switch to HTTP snapshots and save annotated frames

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -8,9 +8,9 @@
         "traffic_phase_lead_sec": 2
     },
     "cameras": {
-        "1": "rtsp://admin:1qazxsw2@192.168.1.111:554/ISAPI/Streaming/Channels/101",
-        "2": "rtsp://admin:1qazxsw2@192.168.1.113:554/ISAPI/Streaming/Channels/101",
-        "3": "rtsp://admin:1qazxsw2@192.168.1.112:554/ISAPI/Streaming/Channels/101"
+        "1": "http://admin:1qazxsw2@192.168.101.2:8881/ISAPI/Streaming/Channels/101/picture?snapShotImageType=JPEG",
+        "2": "http://admin:1qazxsw2@192.168.101.3:8881/ISAPI/Streaming/Channels/101/picture?snapShotImageType=JPEG",
+        "3": "http://admin:1qazxsw2@192.168.101.4:8881/ISAPI/Streaming/Channels/101/picture?snapShotImageType=JPEG"
     },
     "detector": {
         "model_path": "models/yolov5s.pt",
@@ -20,6 +20,9 @@
         "nms_threshold": 0.45
     },
     "mask_dir": "masks/",
+    "snapshots": {
+        "save_dir": "samples/detections"
+    },
     "analysis": {
         "shots_per_phase": 3,
         "phase1_threshold": 50,

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,6 +1,9 @@
 import logging
 import random
 import time
+from pathlib import Path
+
+import cv2
 
 from .config import Config
 from .logger import setup_logging
@@ -26,10 +29,13 @@ def main() -> None:
 
     # Optional video capture initialisation
     vc = None
+    save_dir = None
     try:
         from .video_capture import VideoCapture
 
         vc = VideoCapture(cfg)
+        save_dir = Path(cfg.get("snapshots", "save_dir", default="samples/detections"))
+        save_dir.mkdir(parents=True, exist_ok=True)
     except Exception as exc:  # pragma: no cover - depends on environment
         log.warning("Video capture unavailable, using random frames: %s", exc)
 
@@ -50,8 +56,20 @@ def main() -> None:
                 count = 0
                 for cam_id in cam_ids:
                     frame = vc.read(cam_id) if vc is not None else None
-                    if detector is not None and frame is not None:
-                        count += len(detector.predict(frame))
+                    if frame is None:
+                        log.warning("Frame for camera %s is unavailable, skipping detection", cam_id)
+                        continue
+
+                    if detector is not None:
+                        boxes = detector.predict(frame)
+                        count += len(boxes)
+
+                        if vc is not None and save_dir is not None:
+                            annotated = vc.annotate(cam_id, frame, boxes)
+                            if annotated is not None:
+                                output_path = save_dir / f"camera_{cam_id}.jpg"
+                                if not cv2.imwrite(str(output_path), annotated):
+                                    log.error("Failed to save annotated frame for camera %s", cam_id)
                     else:
                         count += random.randint(0, 5)
                 agg.add(count)

--- a/src/video_capture.py
+++ b/src/video_capture.py
@@ -1,32 +1,47 @@
-import cv2
-import yaml
 import os
 import logging
+from typing import Dict, List, Optional
+
+import cv2
 import numpy as np
+import requests
+import yaml
+
 from .config import Config
 
 class VideoCapture:
     """
-    Захват и маскирование кадров из RTSP-потоков или файлов.
+    Захват и маскирование кадров по HTTP-снимкам.
     Маски хранятся в YAML-файлах `zone_<cam_id>.yaml` в директории mask_dir.
     Каждый файл должен содержать список зон со списком точек в поле `points`.
     """
     def __init__(self, config: Config):
         self._cams = config.get('cameras') or {}
         self._mask_dir = config.get('mask_dir')
-        self._caps = {}
-        self._masks = {}
+        self._session = requests.Session()
+        self._timeout = config.get('cameras_timeout', default=5) or 5
+        self._masks: Dict[str, List[List[int]]] = {}
         self._log = logging.getLogger(self.__class__.__name__)
         self._init_cameras()
         self._load_masks()
 
     def _init_cameras(self):
-        for cam_id, uri in self._cams.items():
-            cap = cv2.VideoCapture(uri)
-            if not cap.isOpened():
-                self._log.error(f"Cannot open camera {cam_id} ({uri})")
-            self._caps[cam_id] = cap
-            self._log.debug(f"Initialized VideoCapture for camera {cam_id}")
+        normalized: Dict[str, str] = {}
+        for cam_id, data in self._cams.items():
+            uri = None
+            if isinstance(data, dict):
+                uri = data.get("snapshot") or data.get("snapshot_url") or data.get("url")
+            elif isinstance(data, str):
+                uri = data
+
+            if not uri:
+                self._log.error(f"Snapshot URL for camera {cam_id} is not provided")
+                continue
+
+            normalized[cam_id] = uri
+            self._log.debug(f"Registered snapshot URL for camera {cam_id}")
+
+        self._cams = normalized
 
     def _load_masks(self):
         for cam_id in self._cams:
@@ -53,25 +68,27 @@ class VideoCapture:
                 self._masks[cam_id] = []
                 self._log.warning(f"Mask file not found for cam {cam_id}, no masking applied.")
 
-    def read(self, cam_id: str):
+    def read(self, cam_id: str) -> Optional[np.ndarray]:
         """
-        Вернуть следующий маскированный кадр для указанной камеры.
+        Вернуть текущий маскированный кадр для указанной камеры.
         """
-        cap = self._caps.get(cam_id)
-        if not cap:
+        uri = self._cams.get(cam_id)
+        if not uri:
             self._log.error(f"Camera {cam_id} not initialized")
             return None
-        ret, frame = cap.read()
-        if not ret:
-            self._log.error(f"Failed to read from camera {cam_id}")
-            if self._restart_camera(cam_id):
-                cap = self._caps.get(cam_id)
-                ret, frame = cap.read() if cap else (False, None)
-                if not ret:
-                    self._log.error(f"Failed to read from camera {cam_id} after restart")
-                    return None
-            else:
-                return None
+
+        try:
+            response = self._session.get(uri, timeout=self._timeout)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            self._log.error(f"Failed to fetch snapshot from camera {cam_id}: {exc}")
+            return None
+
+        frame = cv2.imdecode(np.frombuffer(response.content, dtype=np.uint8), cv2.IMREAD_COLOR)
+        if frame is None:
+            self._log.error(f"Failed to decode snapshot from camera {cam_id}")
+            return None
+
         mask = self._create_mask(frame.shape[:2], self._masks.get(cam_id, []))
         # frame[mask == 0] = 0
         frame = cv2.bitwise_and(frame, frame, mask=mask)
@@ -87,19 +104,25 @@ class VideoCapture:
             cv2.fillPoly(mask, [pts], 255)
         return mask
 
-    def _restart_camera(self, cam_id: str) -> bool:
-        uri = self._cams.get(cam_id)
-        if not uri:
-            self._log.error(f"URI for camera {cam_id} not found")
-            return False
-        cap = self._caps.get(cam_id)
-        if cap:
-            cap.release()
-        new_cap = cv2.VideoCapture(uri)
-        if not new_cap.isOpened():
-            self._log.error(f"Cannot reopen camera {cam_id} ({uri})")
-            self._caps[cam_id] = None
-            return False
-        self._caps[cam_id] = new_cap
-        self._log.info(f"Restarted camera {cam_id}")
-        return True
+    def annotate(self, cam_id: str, frame: np.ndarray, boxes: List[List[int]]) -> Optional[np.ndarray]:
+        """
+        Наложить маски и боксы на кадр.
+        Возвращает аннотированный кадр или None, если входные данные некорректны.
+        """
+        if frame is None or frame.size == 0:
+            return None
+
+        annotated = frame.copy()
+        polygons = self._masks.get(cam_id, [])
+        if polygons:
+            overlay = annotated.copy()
+            for poly in polygons:
+                pts = np.array(poly, dtype=np.int32)
+                cv2.fillPoly(overlay, [pts], (0, 255, 0))
+                cv2.polylines(overlay, [pts], isClosed=True, color=(0, 200, 0), thickness=2)
+            cv2.addWeighted(overlay, 0.3, annotated, 0.7, 0, annotated)
+
+        for x, y, w, h in boxes:
+            cv2.rectangle(annotated, (x, y), (x + w, y + h), (0, 0, 255), 2)
+
+        return annotated


### PR DESCRIPTION
## Summary
- replace the RTSP-based capture with HTTP snapshot fetching and request error handling
- skip detections when snapshots are unavailable and overlay masks and boxes on saved frames
- store the latest annotated frame per camera in a configurable snapshots directory

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d9ae46b868832f9c4380941261628f