### PR TITLE
Handle HTTP snapshot authentication for cameras

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -8,9 +8,30 @@
         "traffic_phase_lead_sec": 2
     },
     "cameras": {
-        "1": "rtsp://admin:1qazxsw2@192.168.1.111:554/ISAPI/Streaming/Channels/101",
-        "2": "rtsp://admin:1qazxsw2@192.168.1.113:554/ISAPI/Streaming/Channels/101",
-        "3": "rtsp://admin:1qazxsw2@192.168.1.112:554/ISAPI/Streaming/Channels/101"
+        "1": {
+            "snapshot": "http://192.168.101.2:8881/ISAPI/Streaming/Channels/101/picture?snapShotImageType=JPEG",
+            "auth": {
+                "type": "digest",
+                "username": "admin",
+                "password": "1qazxsw2"
+            }
+        },
+        "2": {
+            "snapshot": "http://192.168.101.3:8881/ISAPI/Streaming/Channels/101/picture?snapShotImageType=JPEG",
+            "auth": {
+                "type": "digest",
+                "username": "admin",
+                "password": "1qazxsw2"
+            }
+        },
+        "3": {
+            "snapshot": "http://192.168.101.4:8881/ISAPI/Streaming/Channels/101/picture?snapShotImageType=JPEG",
+            "auth": {
+                "type": "digest",
+                "username": "admin",
+                "password": "1qazxsw2"
+            }
+        }
     },
     "detector": {
         "model_path": "models/yolov5s.pt",
@@ -20,6 +41,9 @@
         "nms_threshold": 0.45
     },
     "mask_dir": "masks/",
+    "snapshots": {
+        "save_dir": "samples/detections"
+    },
     "analysis": {
         "shots_per_phase": 3,
         "phase1_threshold": 50,

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,6 +1,9 @@
 import logging
 import random
 import time
+from pathlib import Path
+
+import cv2
 
 from .config import Config
 from .logger import setup_logging
@@ -26,10 +29,13 @@ def main() -> None:
 
     # Optional video capture initialisation
     vc = None
+    save_dir = None
     try:
         from .video_capture import VideoCapture
 
         vc = VideoCapture(cfg)
+        save_dir = Path(cfg.get("snapshots", "save_dir", default="samples/detections"))
+        save_dir.mkdir(parents=True, exist_ok=True)
     except Exception as exc:  # pragma: no cover - depends on environment
         log.warning("Video capture unavailable, using random frames: %s", exc)
 
@@ -50,8 +56,20 @@ def main() -> None:
                 count = 0
                 for cam_id in cam_ids:
                     frame = vc.read(cam_id) if vc is not None else None
-                    if detector is not None and frame is not None:
-                        count += len(detector.predict(frame))
+                    if frame is None:
+                        log.warning("Frame for camera %s is unavailable, skipping detection", cam_id)
+                        continue
+
+                    if detector is not None:
+                        boxes = detector.predict(frame)
+                        count += len(boxes)
+
+                        if vc is not None and save_dir is not None:
+                            annotated = vc.annotate(cam_id, frame, boxes)
+                            if annotated is not None:
+                                output_path = save_dir / f"camera_{cam_id}.jpg"
+                                if not cv2.imwrite(str(output_path), annotated):
+                                    log.error("Failed to save annotated frame for camera %s", cam_id)
                     else:
                         count += random.randint(0, 5)
                 agg.add(count)

--- a/src/video_capture.py
+++ b/src/video_capture.py
@@ -1,32 +1,116 @@
-import cv2
-import yaml
 import os
 import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from urllib.parse import urlparse, urlunparse, unquote
+
+import cv2
 import numpy as np
+import requests
+import yaml
+from requests.auth import AuthBase, HTTPBasicAuth, HTTPDigestAuth
+
 from .config import Config
+
+
+@dataclass
+class CameraEndpoint:
+    url: str
+    auth: Optional[AuthBase] = None
+
 
 class VideoCapture:
     """
-    Захват и маскирование кадров из RTSP-потоков или файлов.
+    Захват и маскирование кадров по HTTP-снимкам.
     Маски хранятся в YAML-файлах `zone_<cam_id>.yaml` в директории mask_dir.
     Каждый файл должен содержать список зон со списком точек в поле `points`.
     """
     def __init__(self, config: Config):
-        self._cams = config.get('cameras') or {}
+        self._cams: Dict[str, CameraEndpoint] = {}
+        raw_cams = config.get('cameras') or {}
         self._mask_dir = config.get('mask_dir')
-        self._caps = {}
-        self._masks = {}
+        self._session = requests.Session()
+        self._timeout = config.get('cameras_timeout', default=5) or 5
+        self._masks: Dict[str, List[List[int]]] = {}
         self._log = logging.getLogger(self.__class__.__name__)
-        self._init_cameras()
+        self._init_cameras(raw_cams)
         self._load_masks()
 
-    def _init_cameras(self):
-        for cam_id, uri in self._cams.items():
-            cap = cv2.VideoCapture(uri)
-            if not cap.isOpened():
-                self._log.error(f"Cannot open camera {cam_id} ({uri})")
-            self._caps[cam_id] = cap
-            self._log.debug(f"Initialized VideoCapture for camera {cam_id}")
+    def _init_cameras(self, raw_cams: Dict[str, object]):
+        for cam_id, data in raw_cams.items():
+            uri = None
+            auth_info = None
+            if isinstance(data, dict):
+                uri = data.get("snapshot") or data.get("snapshot_url") or data.get("url")
+                auth_info = data.get("auth")
+                if not isinstance(auth_info, dict):
+                    auth_info = None
+                fallback_auth = {
+                    key: data.get(key)
+                    for key in ("username", "password", "type", "auth_type")
+                    if data.get(key) is not None
+                }
+                if auth_info is None and fallback_auth:
+                    auth_info = fallback_auth
+            elif isinstance(data, str):
+                uri = data
+
+            if not uri:
+                self._log.error(f"Snapshot URL for camera {cam_id} is not provided")
+                continue
+
+            normalized_url, auth = self._build_auth(cam_id, uri, auth_info)
+            self._cams[cam_id] = CameraEndpoint(url=normalized_url, auth=auth)
+            self._log.debug("Registered snapshot endpoint for camera %s", cam_id)
+
+    def _build_auth(self, cam_id: str, uri: str, auth_info: Optional[Dict[str, object]]):
+        username = None
+        password = None
+        auth_type = None
+
+        if isinstance(auth_info, dict):
+            username = auth_info.get("username") or auth_info.get("user")
+            password = auth_info.get("password")
+            auth_type = auth_info.get("type") or auth_info.get("auth_type")
+
+        parsed = urlparse(uri)
+
+        if parsed.username:
+            url_username = unquote(parsed.username)
+            url_password = unquote(parsed.password or "")
+            if username is None:
+                username = url_username
+            if password is None:
+                password = url_password
+
+        if not username or password is None:
+            if username and password is None:
+                self._log.error(
+                    "Password for camera %s is not provided", cam_id
+                )
+            return uri, None
+
+        auth_type = (auth_type or "digest").lower()
+        if auth_type == "basic":
+            auth = HTTPBasicAuth(username, password)
+        elif auth_type == "digest":
+            auth = HTTPDigestAuth(username, password)
+        else:
+            self._log.warning(
+                "Unknown auth type '%s' for camera %s, defaulting to digest",
+                auth_type,
+                cam_id,
+            )
+            auth = HTTPDigestAuth(username, password)
+
+        sanitized_uri = uri
+        if parsed.username:
+            netloc = parsed.hostname or ""
+            if parsed.port:
+                netloc = f"{netloc}:{parsed.port}"
+            sanitized_uri = urlunparse(parsed._replace(netloc=netloc))
+
+        return sanitized_uri, auth
 
     def _load_masks(self):
         for cam_id in self._cams:
@@ -53,25 +137,42 @@ class VideoCapture:
                 self._masks[cam_id] = []
                 self._log.warning(f"Mask file not found for cam {cam_id}, no masking applied.")
 
-    def read(self, cam_id: str):
+    def read(self, cam_id: str) -> Optional[np.ndarray]:
         """
-        Вернуть следующий маскированный кадр для указанной камеры.
+        Вернуть текущий маскированный кадр для указанной камеры.
         """
-        cap = self._caps.get(cam_id)
-        if not cap:
+        endpoint = self._cams.get(cam_id)
+        if not endpoint:
             self._log.error(f"Camera {cam_id} not initialized")
             return None
-        ret, frame = cap.read()
-        if not ret:
-            self._log.error(f"Failed to read from camera {cam_id}")
-            if self._restart_camera(cam_id):
-                cap = self._caps.get(cam_id)
-                ret, frame = cap.read() if cap else (False, None)
-                if not ret:
-                    self._log.error(f"Failed to read from camera {cam_id} after restart")
-                    return None
-            else:
-                return None
+
+        try:
+            response = self._session.get(
+                endpoint.url,
+                timeout=self._timeout,
+                auth=endpoint.auth,
+            )
+        except requests.RequestException as exc:
+            self._log.error(f"Failed to fetch snapshot from camera {cam_id}: {exc}")
+            return None
+
+        if response.status_code == 401:
+            self._log.warning(
+                "Unauthorized snapshot request for camera %s", cam_id
+            )
+            return None
+
+        try:
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            self._log.error(f"Failed to fetch snapshot from camera {cam_id}: {exc}")
+            return None
+
+        frame = cv2.imdecode(np.frombuffer(response.content, dtype=np.uint8), cv2.IMREAD_COLOR)
+        if frame is None:
+            self._log.error(f"Failed to decode snapshot from camera {cam_id}")
+            return None
+
         mask = self._create_mask(frame.shape[:2], self._masks.get(cam_id, []))
         # frame[mask == 0] = 0
         frame = cv2.bitwise_and(frame, frame, mask=mask)
@@ -87,19 +188,25 @@ class VideoCapture:
             cv2.fillPoly(mask, [pts], 255)
         return mask
 
-    def _restart_camera(self, cam_id: str) -> bool:
-        uri = self._cams.get(cam_id)
-        if not uri:
-            self._log.error(f"URI for camera {cam_id} not found")
-            return False
-        cap = self._caps.get(cam_id)
-        if cap:
-            cap.release()
-        new_cap = cv2.VideoCapture(uri)
-        if not new_cap.isOpened():
-            self._log.error(f"Cannot reopen camera {cam_id} ({uri})")
-            self._caps[cam_id] = None
-            return False
-        self._caps[cam_id] = new_cap
-        self._log.info(f"Restarted camera {cam_id}")
-        return True
+    def annotate(self, cam_id: str, frame: np.ndarray, boxes: List[List[int]]) -> Optional[np.ndarray]:
+        """
+        Наложить маски и боксы на кадр.
+        Возвращает аннотированный кадр или None, если входные данные некорректны.
+        """
+        if frame is None or frame.size == 0:
+            return None
+
+        annotated = frame.copy()
+        polygons = self._masks.get(cam_id, [])
+        if polygons:
+            overlay = annotated.copy()
+            for poly in polygons:
+                pts = np.array(poly, dtype=np.int32)
+                cv2.fillPoly(overlay, [pts], (0, 255, 0))
+                cv2.polylines(overlay, [pts], isClosed=True, color=(0, 200, 0), thickness=2)
+            cv2.addWeighted(overlay, 0.3, annotated, 0.7, 0, annotated)
+
+        for x, y, w, h in boxes:
+            cv2.rectangle(annotated, (x, y), (x + w, y + h), (0, 0, 255), 2)
+
+        return annotated


### PR DESCRIPTION
## Summary
- allow configuring per-camera authentication for HTTP snapshots and normalise camera endpoints
- update the snapshot reader to attach the configured auth when requesting frames and warn on unauthorized responses
- refresh the default configuration to demonstrate digest credentials without embedding them in the URL

## Testing
- python -m compileall src
- python -m compileall src/video_capture.py

------
https://chatgpt.com/codex/tasks/task_e_68d9ae46b868832f9c4380941261628f