### PR TITLE
Refactor main utilities into separate modules

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,172 +1,24 @@
 import logging
-from pathlib import Path
 import shutil
-from datetime import datetime
 import time
 import traceback
-
-import cv2
-
+from pathlib import Path
 from .config import Config
-from .logger import setup_logging
-from .analyzer import CountsAggregator
-from .video_capture import VideoCapture
-from .detector import Detector
 from .controller_client import ControllerClient
 from .decision import DecisionEngine
-from logging.handlers import RotatingFileHandler
+from .detector import Detector
+from .logger import setup_logging
+from .service_utils import count_direction, setup_progchange_logger
+from .snapshots import format_bytes, is_saving_allowed, space_ok, today_dir
+from .video_capture import VideoCapture
 
-# ---------- цвета BGR для классов ----------
-CLASS_COLOR = {
-    "car":   (0, 255, 0),     # зелёный
-    "truck": (0, 165, 255),   # оранжевый
-    "bus":   (255, 0, 0),     # синий
-}
-
-# ---------- утилиты сохранения кадров ----------
-def _today_dir(root: Path) -> Path:
-    return root / datetime.now().strftime("%Y%m%d")
-
-def _timestamp_name(ext: str = "jpg") -> str:
-    return datetime.now().strftime("%H%M%S_%f")[:-3] + "." + ext
-
-def _unique_path(dir_, fname):
-    p = dir_ / fname
-    if not p.exists():
-        return p
-    stem, suf = p.stem, p.suffix
-    k = 1
-    while True:
-        cand = dir_ / ("%s_%d%s" % (stem, k, suf))
-        if not cand.exists():
-            return cand
-        k += 1
-
-def _fmt_bytes(n):
-    for unit in ("B", "KB", "MB", "GB", "TB"):
-        if n < 1024:
-            return "%d %s" % (n, unit)
-        n //= 1024
-    return "%d PB" % n
-
-def _is_saving_allowed(root: Path, min_free_gb: float, log: logging.Logger) -> bool:
-    try:
-        root.mkdir(parents=True, exist_ok=True)
-        probe = root / ".write_test"
-        probe.write_text("ok", encoding="utf-8")
-        probe.unlink()
-        usage = shutil.disk_usage(root)
-        return usage.free >= int(min_free_gb * (1024 ** 3))
-    except Exception as e:
-        log.error("Snapshots disabled: %s", e)
-        return False
-
-def _space_ok(root: Path, min_free_gb: float):
-    try:
-        usage = shutil.disk_usage(root)
-        return (usage.free >= int(min_free_gb * (1024 ** 3))), usage.free
-    except Exception:
-        return False, 0
-
-def _save_frame(path: Path, img) -> bool:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        return bool(cv2.imwrite(str(path), img))
-    except Exception:
-        return False
-
-def _draw_detections(img, detections):
-    annotated = img.copy()
-    font = cv2.FONT_HERSHEY_SIMPLEX
-    font_scale = 0.5
-    thickness = 2
-
-    for det in detections:
-        try:
-            if "xyxy" in det:
-                x1, y1, x2, y2 = det["xyxy"]
-            elif "bbox" in det:
-                x1, y1, x2, y2 = det["bbox"]
-            elif "xywh" in det:
-                x, y, w, h = det["xywh"]
-                x1, y1, x2, y2 = int(x - w/2), int(y - h/2), int(x + w/2), int(y + h/2)
-            else:
-                continue
-
-            name = det.get("name", "obj")
-            conf = det.get("conf")
-            color = CLASS_COLOR.get(name, (0, 255, 255))
-
-            cv2.rectangle(annotated, (int(x1), int(y1)), (int(x2), int(y2)), color, 2)
-            label = "%s%s" % (name, (" %.2f" % float(conf)) if conf is not None else "")
-            (tw, th), _ = cv2.getTextSize(label, font, font_scale, thickness)
-            cv2.rectangle(annotated, (int(x1), int(y1) - th - 6), (int(x1) + tw + 4, int(y1)), color, -1)
-            cv2.putText(annotated, label, (int(x1) + 2, int(y1) - 4),
-                        font, font_scale, (255, 255, 255), 1, cv2.LINE_AA)
-        except Exception:
-            continue
-
-    return annotated
-
-# ---------- логгер смен программ (отдельный файл) ----------
-def _setup_progchange_logger(cfg: Config) -> logging.Logger:
-    path = cfg.get("logging", "program_changes_file", default="logs/program_changes.log")
-    level_name = cfg.get("logging", "level", default="INFO")
-    level = getattr(logging, str(level_name).upper(), logging.INFO)
-    max_bytes = cfg.get("logging", "max_bytes", default=10_485_760)
-    backup_count = cfg.get("logging", "backup_count", default=5)
-
-    logger = logging.getLogger("progchange")
-    logger.setLevel(level)
-    logger.propagate = False  # чтобы не дублировать в общий лог
-
-    if not logger.handlers:
-        log_dir = Path(path).parent
-        log_dir.mkdir(parents=True, exist_ok=True)
-        fh = RotatingFileHandler(path, maxBytes=int(max_bytes), backupCount=int(backup_count), encoding="utf-8")
-        # CSV: timestamp,FROM,TO
-        fmt = logging.Formatter("%(asctime)s,%(message)s", datefmt="%Y-%m-%d %H:%M:%S.%f")
-        fh.setFormatter(fmt)
-        fh.setLevel(level)
-        logger.addHandler(fh)
-    return logger
-
-# ---------- съём очереди ----------
-def _count_direction(detector, vc, cam_ids, shots, log, save_dir):
-    agg = CountsAggregator()
-    for _ in range(max(1, int(shots))):
-        total = 0
-        for cam_id in cam_ids:
-            frame = vc.read(cam_id)
-            if frame is None:
-                log.warning("Frame for camera %s is unavailable, skipping detection", cam_id)
-                continue
-
-            dets = detector.predict(frame) if detector else []
-            count = sum(1 for d in dets if d.get("name") in ("car", "bus", "truck"))
-            total += count
-
-            out_img = _draw_detections(frame, dets) if dets else frame
-
-            if save_dir is not None:
-                cam_dir = save_dir / ("cam_%s" % cam_id)
-                cam_dir.mkdir(parents=True, exist_ok=True)
-                fname = _timestamp_name("jpg")
-                out_path = _unique_path(cam_dir, fname)
-                if _save_frame(out_path, out_img):
-                    logging.getLogger("service").info("Saved snapshot for camera %s: %s", cam_id, out_path.resolve())
-                else:
-                    logging.getLogger("service").error("Failed to save frame for camera %s to %s", cam_id, out_path)
-
-        agg.add(total)
-    return int(round(agg.average()))
 
 # ---------- главный сервис ----------
 def main():
     cfg = Config()
     setup_logging(cfg)
     log = logging.getLogger("service")
-    proglog = _setup_progchange_logger(cfg)  # отдельный файл смен программ
+    proglog = setup_progchange_logger(cfg)  # отдельный файл смен программ
 
     # Контроллер
     client = ControllerClient(cfg)
@@ -190,11 +42,11 @@ def main():
     # Снимки: включение/лог
     save_root = Path(cfg.get("snapshots", "save_dir", default="/media/MYUSB/neyro_det"))
     min_free_gb = float(cfg.get("snapshots", "min_free_gb", default=1.0))
-    saving_globally_enabled = _is_saving_allowed(save_root, min_free_gb, log)
+    saving_globally_enabled = is_saving_allowed(save_root, min_free_gb, log)
     if saving_globally_enabled:
         free = shutil.disk_usage(save_root).free
         log.info("Snapshots ENABLED at: %s (free: %s, threshold: %.2f GB)",
-                 save_root.resolve(), _fmt_bytes(free), min_free_gb)
+                 save_root.resolve(), format_bytes(free), min_free_gb)
     else:
         log.error("Snapshots DISABLED: saving will be skipped (no fallback).")
 
@@ -239,14 +91,14 @@ def main():
             # 0) свободное место — решаем, сохранять ли кадры
             saving_allowed = False
             if saving_globally_enabled:
-                ok, free = _space_ok(save_root, min_free_gb)
+                ok, free = space_ok(save_root, min_free_gb)
                 if ok:
                     saving_allowed = True
                 else:
                     log.warning("Snapshots PAUSED: low disk space at %s (free: %s < %.2f GB).",
-                                save_root.resolve(), _fmt_bytes(free), min_free_gb)
+                                save_root.resolve(), format_bytes(free), min_free_gb)
 
-            day_dir = _today_dir(save_root) if saving_allowed else None
+            day_dir = today_dir(save_root) if saving_allowed else None
             if day_dir is not None:
                 day_dir.mkdir(parents=True, exist_ok=True)
 
@@ -285,7 +137,7 @@ def main():
                     log.info("[PHASE] 2->1  (side RED start)")
             prev_phase = phase
 
-            # 3) съём очередей «через N секунд после начала красного»
+            # 3) съём очередей «через N секунд посе начала красного»
             now = time.time()
 
             # main: замерить только когда main на красном (фаза 2)
@@ -295,8 +147,8 @@ def main():
                 (now - main_red_t0) >= red_delay and
                 main_sampled_cycle != cycle_id
             ):
-                q = _count_direction(detector, vc, main_cams, shots_per_probe, log,
-                                     (day_dir / "main") if day_dir else None)
+                q = count_direction(detector, vc, main_cams, shots_per_probe, log,
+                                    (day_dir / "main") if day_dir else None)
                 last_q_main = q
                 main_sampled_cycle = cycle_id
                 main_red_t0 = None  # сброс, чтобы не пересчитать повторно
@@ -309,8 +161,8 @@ def main():
                 (now - side_red_t0) >= red_delay and
                 side_sampled_cycle != cycle_id
             ):
-                q = _count_direction(detector, vc, side_cams, shots_per_probe, log,
-                                     (day_dir / "side") if day_dir else None)
+                q = count_direction(detector, vc, side_cams, shots_per_probe, log,
+                                    (day_dir / "side") if day_dir else None)
                 last_q_side = q
                 side_sampled_cycle = cycle_id
                 side_red_t0 = None  # сброс
@@ -346,6 +198,7 @@ def main():
         log.info("Shutting down service")
     finally:
         client.close()
+
 
 if __name__ == "__main__":
     main()

--- a/src/service_utils.py
+++ b/src/service_utils.py
@@ -1,0 +1,61 @@
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from logging.handlers import RotatingFileHandler
+
+from .analyzer import CountsAggregator
+from .snapshots import draw_detections, save_frame, timestamp_name, unique_path
+
+
+def setup_progchange_logger(cfg) -> logging.Logger:
+    path = cfg.get("logging", "program_changes_file", default="logs/program_changes.log")
+    level_name = cfg.get("logging", "level", default="INFO")
+    level = getattr(logging, str(level_name).upper(), logging.INFO)
+    max_bytes = cfg.get("logging", "max_bytes", default=10_485_760)
+    backup_count = cfg.get("logging", "backup_count", default=5)
+
+    logger = logging.getLogger("progchange")
+    logger.setLevel(level)
+    logger.propagate = False  # чтобы не дублировать в общий лог
+
+    if not logger.handlers:
+        log_dir = Path(path).parent
+        log_dir.mkdir(parents=True, exist_ok=True)
+        fh = RotatingFileHandler(path, maxBytes=int(max_bytes), backupCount=int(backup_count), encoding="utf-8")
+        # CSV: timestamp,FROM,TO
+        fmt = logging.Formatter("%(asctime)s,%(message)s", datefmt="%Y-%m-%d %H:%M:%S.%f")
+        fh.setFormatter(fmt)
+        fh.setLevel(level)
+        logger.addHandler(fh)
+    return logger
+
+
+def count_direction(detector, vc, cam_ids: Iterable[str], shots: int, log: logging.Logger, save_dir: Path):
+    agg = CountsAggregator()
+    for _ in range(max(1, int(shots))):
+        total = 0
+        for cam_id in cam_ids:
+            frame = vc.read(cam_id)
+            if frame is None:
+                log.warning("Frame for camera %s is unavailable, skipping detection", cam_id)
+                continue
+
+            dets = detector.predict(frame) if detector else []
+            count = sum(1 for d in dets if d.get("name") in ("car", "bus", "truck"))
+            total += count
+
+            out_img = draw_detections(frame, dets) if dets else frame
+
+            if save_dir is not None:
+                cam_dir = save_dir / ("cam_%s" % cam_id)
+                cam_dir.mkdir(parents=True, exist_ok=True)
+                fname = timestamp_name("jpg")
+                out_path = unique_path(cam_dir, fname)
+                if save_frame(out_path, out_img):
+                    logging.getLogger("service").info("Saved snapshot for camera %s: %s", cam_id, out_path.resolve())
+                else:
+                    logging.getLogger("service").error("Failed to save frame for camera %s to %s", cam_id, out_path)
+
+        agg.add(total)
+    return int(round(agg.average()))

--- a/src/snapshots.py
+++ b/src/snapshots.py
@@ -1,0 +1,106 @@
+import logging
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import cv2
+
+# ---------- цвета BGR для классов ----------
+CLASS_COLOR = {
+    "car": (0, 255, 0),  # зелёный
+    "truck": (0, 165, 255),  # оранжевый
+    "bus": (255, 0, 0),  # синий
+}
+
+
+def today_dir(root: Path) -> Path:
+    return root / datetime.now().strftime("%Y%m%d")
+
+
+def timestamp_name(ext: str = "jpg") -> str:
+    return datetime.now().strftime("%H%M%S_%f")[:-3] + "." + ext
+
+
+def unique_path(dir_: Path, fname: str) -> Path:
+    p = dir_ / fname
+    if not p.exists():
+        return p
+    stem, suf = p.stem, p.suffix
+    k = 1
+    while True:
+        cand = dir_ / ("%s_%d%s" % (stem, k, suf))
+        if not cand.exists():
+            return cand
+        k += 1
+
+
+def format_bytes(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024:
+            return "%d %s" % (n, unit)
+        n //= 1024
+    return "%d PB" % n
+
+
+def is_saving_allowed(root: Path, min_free_gb: float, log: logging.Logger) -> bool:
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        probe = root / ".write_test"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+        usage = shutil.disk_usage(root)
+        return usage.free >= int(min_free_gb * (1024 ** 3))
+    except Exception as e:
+        log.error("Snapshots disabled: %s", e)
+        return False
+
+
+def space_ok(root: Path, min_free_gb: float) -> Tuple[bool, int]:
+    try:
+        usage = shutil.disk_usage(root)
+        return (usage.free >= int(min_free_gb * (1024 ** 3))), usage.free
+    except Exception:
+        return False, 0
+
+
+def save_frame(path: Path, img) -> bool:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        return bool(cv2.imwrite(str(path), img))
+    except Exception:
+        return False
+
+
+def draw_detections(img, detections: Iterable[dict]):
+    annotated = img.copy()
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    font_scale = 0.5
+    thickness = 2
+
+    for det in detections:
+        try:
+            if "xyxy" in det:
+                x1, y1, x2, y2 = det["xyxy"]
+            elif "bbox" in det:
+                x1, y1, x2, y2 = det["bbox"]
+            elif "xywh" in det:
+                x, y, w, h = det["xywh"]
+                x1, y1, x2, y2 = int(x - w / 2), int(y - h / 2), int(x + w / 2), int(y + h / 2)
+            else:
+                continue
+
+            name = det.get("name", "obj")
+            conf = det.get("conf")
+            color = CLASS_COLOR.get(name, (0, 255, 255))
+
+            cv2.rectangle(annotated, (int(x1), int(y1)), (int(x2), int(y2)), color, 2)
+            label = "%s%s" % (name, (" %.2f" % float(conf)) if conf is not None else "")
+            (tw, th), _ = cv2.getTextSize(label, font, font_scale, thickness)
+            cv2.rectangle(annotated, (int(x1), int(y1) - th - 6), (int(x1) + tw + 4, int(y1)), color, -1)
+            cv2.putText(annotated, label, (int(x1) + 2, int(y1) - 4),
+                        font, font_scale, (255, 255, 255), 1, cv2.LINE_AA)
+        except Exception:
+            continue
+
+    return annotated


### PR DESCRIPTION
## Summary
- move snapshot utilities and frame annotation helpers into a dedicated module
- extract program-change logging and direction counting helpers out of the main entrypoint
- streamline the main service file to focus on configuration and orchestration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef8a92458832f88d0f846111af1d4)